### PR TITLE
Rename to include tiny and add v7 yaml

### DIFF
--- a/cfg/training/yolov7-textbox.yaml
+++ b/cfg/training/yolov7-textbox.yaml
@@ -5,108 +5,136 @@ width_multiple: 1.0  # layer channel multiple
 
 # anchors
 anchors:
-  - [10,13, 16,30, 33,23]  # P3/8
-  - [30,61, 62,45, 59,119]  # P4/16
-  - [116,90, 156,198, 373,326]  # P5/32
+  - [12,16, 19,36, 40,28]  # P3/8
+  - [36,75, 76,55, 72,146]  # P4/16
+  - [142,110, 192,243, 459,401]  # P5/32
 
-# yolov7-tiny backbone
+# yolov7 backbone
 backbone:
-  # [from, number, module, args] c2, k=1, s=1, p=None, g=1, act=True
-  [[-1, 1, Conv, [32, 3, 2, None, 1, nn.LeakyReLU(0.1)]],  # 0-P1/2  
+  # [from, number, module, args]
+  [[-1, 1, Conv, [32, 3, 1]],  # 0
   
-   [-1, 1, Conv, [64, 3, 2, None, 1, nn.LeakyReLU(0.1)]],  # 1-P2/4    
+   [-1, 1, Conv, [64, 3, 2]],  # 1-P1/2      
+   [-1, 1, Conv, [64, 3, 1]],
    
-   [-1, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 7
-   
-   [-1, 1, MP, []],  # 8-P3/8
-   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 14
-   
-   [-1, 1, MP, []],  # 15-P4/16
-   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 21
-   
-   [-1, 1, MP, []],  # 22-P5/32
-   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [256, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [256, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [512, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 28
+   [-1, 1, Conv, [128, 3, 2]],  # 3-P2/4  
+   [-1, 1, Conv, [64, 1, 1]],
+   [-2, 1, Conv, [64, 1, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [[-1, -3, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1]],  # 11
+         
+   [-1, 1, MP, []],
+   [-1, 1, Conv, [128, 1, 1]],
+   [-3, 1, Conv, [128, 1, 1]],
+   [-1, 1, Conv, [128, 3, 2]],
+   [[-1, -3], 1, Concat, [1]],  # 16-P3/8  
+   [-1, 1, Conv, [128, 1, 1]],
+   [-2, 1, Conv, [128, 1, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [[-1, -3, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [512, 1, 1]],  # 24
+         
+   [-1, 1, MP, []],
+   [-1, 1, Conv, [256, 1, 1]],
+   [-3, 1, Conv, [256, 1, 1]],
+   [-1, 1, Conv, [256, 3, 2]],
+   [[-1, -3], 1, Concat, [1]],  # 29-P4/16  
+   [-1, 1, Conv, [256, 1, 1]],
+   [-2, 1, Conv, [256, 1, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [[-1, -3, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [1024, 1, 1]],  # 37
+         
+   [-1, 1, MP, []],
+   [-1, 1, Conv, [512, 1, 1]],
+   [-3, 1, Conv, [512, 1, 1]],
+   [-1, 1, Conv, [512, 3, 2]],
+   [[-1, -3], 1, Concat, [1]],  # 42-P5/32  
+   [-1, 1, Conv, [256, 1, 1]],
+   [-2, 1, Conv, [256, 1, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [[-1, -3, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [1024, 1, 1]],  # 50
   ]
 
-# yolov7-tiny head
+# yolov7 head
 head:
-  [[-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, SP, [5]],
-   [-2, 1, SP, [9]],
-   [-3, 1, SP, [13]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -7], 1, Concat, [1]],
-   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 37
+  [[-1, 1, SPPCSPC, [512]], # 51
   
-   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [256, 1, 1]],
    [-1, 1, nn.Upsample, [None, 2, 'nearest']],
-   [21, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]], # route backbone P4
+   [37, 1, Conv, [256, 1, 1]], # route backbone P4
    [[-1, -2], 1, Concat, [1]],
    
-   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 47
-  
-   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [256, 1, 1]],
+   [-2, 1, Conv, [256, 1, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [[-1, -2, -3, -4, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1]], # 63
+   
+   [-1, 1, Conv, [128, 1, 1]],
    [-1, 1, nn.Upsample, [None, 2, 'nearest']],
-   [14, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]], # route backbone P3
+   [24, 1, Conv, [128, 1, 1]], # route backbone P3
    [[-1, -2], 1, Concat, [1]],
    
-   [-1, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 57
-   
-   [-1, 1, Conv, [128, 3, 2, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, 47], 1, Concat, [1]],
-   
-   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 65
-   
-   [-1, 1, Conv, [256, 3, 2, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, 37], 1, Concat, [1]],
-   
-   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-2, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [[-1, -2, -3, -4], 1, Concat, [1]],
-   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 73
+   [-1, 1, Conv, [128, 1, 1]],
+   [-2, 1, Conv, [128, 1, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [-1, 1, Conv, [64, 3, 1]],
+   [[-1, -2, -3, -4, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [128, 1, 1]], # 75
       
-   [57, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [65, 1, Conv, [256, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
-   [73, 1, Conv, [512, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, MP, []],
+   [-1, 1, Conv, [128, 1, 1]],
+   [-3, 1, Conv, [128, 1, 1]],
+   [-1, 1, Conv, [128, 3, 2]],
+   [[-1, -3, 63], 1, Concat, [1]],
+   
+   [-1, 1, Conv, [256, 1, 1]],
+   [-2, 1, Conv, [256, 1, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [-1, 1, Conv, [128, 3, 1]],
+   [[-1, -2, -3, -4, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1]], # 88
+      
+   [-1, 1, MP, []],
+   [-1, 1, Conv, [256, 1, 1]],
+   [-3, 1, Conv, [256, 1, 1]],
+   [-1, 1, Conv, [256, 3, 2]],
+   [[-1, -3, 51], 1, Concat, [1]],
+   
+   [-1, 1, Conv, [512, 1, 1]],
+   [-2, 1, Conv, [512, 1, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [-1, 1, Conv, [256, 3, 1]],
+   [[-1, -2, -3, -4, -5, -6], 1, Concat, [1]],
+   [-1, 1, Conv, [512, 1, 1]], # 101
+   
+   [75, 1, RepConv, [256, 3, 1]],
+   [88, 1, RepConv, [512, 3, 1]],
+   [101, 1, RepConv, [1024, 3, 1]],
 
-   [[74,75,76], 1, IDetect, [nc, anchors]],   # Detect(P3, P4, P5)
+   [[102,103,104], 1, IDetect, [nc, anchors]],   # Detect(P3, P4, P5)
   ]

--- a/cfg/training/yolov7-tiny-textbox.yaml
+++ b/cfg/training/yolov7-tiny-textbox.yaml
@@ -1,0 +1,112 @@
+# parameters
+nc: 2  # number of classes
+depth_multiple: 1.0  # model depth multiple
+width_multiple: 1.0  # layer channel multiple
+
+# anchors
+anchors:
+  - [10,13, 16,30, 33,23]  # P3/8
+  - [30,61, 62,45, 59,119]  # P4/16
+  - [116,90, 156,198, 373,326]  # P5/32
+
+# yolov7-tiny backbone
+backbone:
+  # [from, number, module, args] c2, k=1, s=1, p=None, g=1, act=True
+  [[-1, 1, Conv, [32, 3, 2, None, 1, nn.LeakyReLU(0.1)]],  # 0-P1/2  
+  
+   [-1, 1, Conv, [64, 3, 2, None, 1, nn.LeakyReLU(0.1)]],  # 1-P2/4    
+   
+   [-1, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 7
+   
+   [-1, 1, MP, []],  # 8-P3/8
+   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 14
+   
+   [-1, 1, MP, []],  # 15-P4/16
+   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 21
+   
+   [-1, 1, MP, []],  # 22-P5/32
+   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [256, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [256, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [512, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 28
+  ]
+
+# yolov7-tiny head
+head:
+  [[-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, SP, [5]],
+   [-2, 1, SP, [9]],
+   [-3, 1, SP, [13]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -7], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 37
+  
+   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, nn.Upsample, [None, 2, 'nearest']],
+   [21, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]], # route backbone P4
+   [[-1, -2], 1, Concat, [1]],
+   
+   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 47
+  
+   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, nn.Upsample, [None, 2, 'nearest']],
+   [14, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]], # route backbone P3
+   [[-1, -2], 1, Concat, [1]],
+   
+   [-1, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [32, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [32, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 57
+   
+   [-1, 1, Conv, [128, 3, 2, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, 47], 1, Concat, [1]],
+   
+   [-1, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [64, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [64, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 65
+   
+   [-1, 1, Conv, [256, 3, 2, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, 37], 1, Concat, [1]],
+   
+   [-1, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-2, 1, Conv, [128, 1, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [-1, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [[-1, -2, -3, -4], 1, Concat, [1]],
+   [-1, 1, Conv, [256, 1, 1, None, 1, nn.LeakyReLU(0.1)]],  # 73
+      
+   [57, 1, Conv, [128, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [65, 1, Conv, [256, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+   [73, 1, Conv, [512, 3, 1, None, 1, nn.LeakyReLU(0.1)]],
+
+   [[74,75,76], 1, IDetect, [nc, anchors]],   # Detect(P3, P4, P5)
+  ]


### PR DESCRIPTION
The textbox.yaml is renamed to include tiny to be more precise. A new file is added which is meant for the actual yolov7 training.